### PR TITLE
menu fixes

### DIFF
--- a/src/core/ProgramData.cpp
+++ b/src/core/ProgramData.cpp
@@ -189,6 +189,13 @@ uint16_t ProgramData::getMaxCells()
     return MAX_CHARGE_V / v;
 }
 
+uint16_t ProgramData::cellCount()
+{
+    if(battery.type == UnknownBatteryType || battery.type == LED)
+        return 1;
+    return battery.cells;
+}
+
 void ProgramData::check()
 {
     uint16_t v;

--- a/src/core/ProgramData.h
+++ b/src/core/ProgramData.h
@@ -87,6 +87,7 @@ namespace ProgramData {
     inline int16_t getDeltaTLimit() {return battery.deltaT;}
 
     uint16_t getMaxCells();
+    uint16_t cellCount();
     uint16_t getMaxIc();
     uint16_t getMaxId();
 

--- a/src/core/menus/ProgramMenus.cpp
+++ b/src/core/menus/ProgramMenus.cpp
@@ -52,6 +52,18 @@ namespace ProgramMenus {
             Program::EditBattery,
     };
 
+    const Program::ProgramType programLiXX1CellMenu[] PROGMEM = {
+            Program::Charge,
+            Program::Discharge,
+            Program::FastCharge,
+            Program::Storage,
+#ifdef ENABLE_PROGRAM_MENUS_LIXX_CYCLING
+            Program::DischargeChargeCycle,
+#endif
+            Program::CapacityCheck,
+            Program::EditBattery,
+    };
+
     const Program::ProgramType programNiZnMenu[] PROGMEM = {
             Program::Charge,
             Program::ChargeBalance,
@@ -109,8 +121,11 @@ namespace ProgramMenus {
             return programNoneMenu;
         if(bc == ProgramData::ClassNiZn)
             return programNiZnMenu;
-        if(bc == ProgramData::ClassLiXX)
+        if(bc == ProgramData::ClassLiXX) {
+            if (ProgramData::battery.cells == 1)
+                return programLiXX1CellMenu;
             return programLiXXMenu;
+        }
         if(bc == ProgramData::ClassNiXX)
             return programNiXXMenu;
         if(bc == ProgramData::ClassLED)

--- a/src/core/screens/Screen.cpp
+++ b/src/core/screens/Screen.cpp
@@ -49,6 +49,10 @@ namespace Screen {
             c += PAGE_BALANCE_PORT;
         c += PAGE_BATTERY(ProgramData::getBatteryClass());
         c += PAGE_PROGRAM(Program::programType);
+        if(ProgramData::cellCount() < 4)
+            c += PAGE_BELOW_4CELL;
+        if(ProgramData::cellCount() < 7)
+            c += PAGE_BELOW_7CELL;
         return c;
     }
 

--- a/src/core/screens/Screen.h
+++ b/src/core/screens/Screen.h
@@ -37,8 +37,12 @@
 
 #define PAGE_START_INFO             (1L<<30)
 #define PAGE_BALANCE_PORT           (1L<<29)
-#define PAGE_PROGRAM(program)       (1<<(program))
+#define PAGE_BELOW_7CELL            (1L<<28)
+#define PAGE_BELOW_4CELL            (1L<<27)
+// 6 battery classes
 #define PAGE_BATTERY(_class)        ((1<<9)<<(_class))
+// 11 program types
+#define PAGE_PROGRAM(program)       (1<<(program))
 
 namespace Screen {
 

--- a/src/core/screens/ScreenPages.h
+++ b/src/core/screens/ScreenPages.h
@@ -53,14 +53,14 @@ namespace Screen { namespace Pages {
             {Screen::Methods::displayEnergy,        PAGE_ALWAYS, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance)},
 
             {Screen::Balancer::displayVoltage1_3,   PAGE_START_INFO + PAGE_BALANCE_PORT , PAGE_NONE},
-            {Screen::Balancer::displayVoltage4_6,   PAGE_START_INFO + PAGE_BALANCE_PORT , PAGE_NONE},
+            {Screen::Balancer::displayVoltage4_6,   PAGE_START_INFO + PAGE_BALANCE_PORT , PAGE_BELOW_4CELL},
 BALANCER_PORTS_GT_6(
-            {Screen::Balancer::displayVoltage7_9,   PAGE_START_INFO + PAGE_BALANCE_PORT , PAGE_NONE},)
+            {Screen::Balancer::displayVoltage7_9,   PAGE_START_INFO + PAGE_BALANCE_PORT , PAGE_BELOW_7CELL},)
 
             {Screen::Balancer::displayResistance1_3,PAGE_BALANCE_PORT, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance)},
-            {Screen::Balancer::displayResistance4_6,PAGE_BALANCE_PORT, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance)},
+            {Screen::Balancer::displayResistance4_6,PAGE_BALANCE_PORT, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance) + PAGE_BELOW_4CELL},
 BALANCER_PORTS_GT_6(
-            {Screen::Balancer::displayResistance7_9,PAGE_BALANCE_PORT, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance)},)
+            {Screen::Balancer::displayResistance7_9,PAGE_BALANCE_PORT, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance) + PAGE_BELOW_7CELL},)
 
             {Screen::Methods::displayR,             PAGE_ALWAYS, PAGE_START_INFO + PAGE_PROGRAM(Program::Balance)},
 


### PR DESCRIPTION
- Hide balance menu items if single cell battery is selected
- Disable screens displaying cells data above 3 and 6 cells if the charged packs has fewer cells